### PR TITLE
Update Connections.R

### DIFF
--- a/R/Connections.R
+++ b/R/Connections.R
@@ -73,14 +73,14 @@ odbcConnStrBOA <- paste0("Driver={ODBC Driver 17 for SQL Server};
 
 
 odbcConnStrSynpase <- paste0("Driver={ODBC Driver 17 for SQL Server};
-                 Server=anpd-mida-synapse-workspace.sql.azuresynapse.net;
-                 database=anpd_mida_sql_pool;
-                 Uid={", uidBOA, "};
-                 Pwd={", pwdBOA, "};
-                 Encrypt=yes;
-                 TrustServerCertificate=no;
-                 Connection Timeout=1000;
-                 Authentication=ActiveDirectoryPassword;")
+                Server=anpd-mida-synapse-workspace.sql.azuresynapse.net;
+                database=anpd_mida_sql_pool;
+                #Uid={", uidBOA, "};
+                #Pwd={", pwdBOA, "};
+                Encrypt=yes;
+                TrustServerCertificate=yes;
+                Connection Timeout=1000;
+                Authentication=ActiveDirectoryIntegrated;")
 
 
 


### PR DESCRIPTION
updating odbcConnStrSynpase (yes it is misspelled this way today).

Context:
So we kept seeing this ODBC error on R scripts ran on the M machine.  My password files are up to date, so it isn’t that.  I did some research and there are complaints about ODBC active directory being an issue with the move to Entra.  I successfully tested the below changes and DSN creation on my CGODBCError branch in Automation Scripts, CG_ODBC_ERROR_Testing.R.  Please also test and let me know your thoughts before we try making any pull requests/changes to the connections package.

I think we need to update the odbcConnStrSynpase in Connections to:
odbcConnStrSynpase <- paste0("Driver={ODBC Driver 17 for SQL Server};
                 Server=anpd-mida-synapse-workspace.sql.azuresynapse.net;
                 database=anpd_mida_sql_pool;
                 #Uid={", uidBOA, "};
                 #Pwd={", pwdBOA, "};
                 Encrypt=yes;
                 TrustServerCertificate=yes;
                 Connection Timeout=1000;
                 Authentication=ActiveDirectoryIntegrated;")

I also created a system DSN:
![image](https://github.com/user-attachments/assets/465cd254-1738-41b7-a13f-eaafc9494c97)
![image](https://github.com/user-attachments/assets/b64888ab-7a50-450b-8e0a-c5809c174f46)
![image](https://github.com/user-attachments/assets/0c55a797-03ed-4fe8-946f-670f4e3dcae4)
![image](https://github.com/user-attachments/assets/39eedb43-cad8-4663-96ec-6e7ef5bfc9af)
![image](https://github.com/user-attachments/assets/1bb4d814-c02c-4d03-828f-6f8b5fb98835)

